### PR TITLE
download many codelists

### DIFF
--- a/src/main/frontend/src/app/app.component.ts
+++ b/src/main/frontend/src/app/app.component.ts
@@ -16,7 +16,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import { Component, Injectable } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Injectable,
+  Output,
+} from '@angular/core';
 import { LoadingService } from './loading.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { NavigationEnd, Router } from '@angular/router';
@@ -24,22 +30,31 @@ import { NavigationEnd, Router } from '@angular/router';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
+  styleUrls: ['./app.component.scss'],
 })
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AppComponent {
+  static instance: AppComponent | null = null;
   title = 'CodeMapper';
+  @Output() espapePressed = new EventEmitter<null>();
   constructor(
-    public loadingService : LoadingService,
-    router : Router,
-    snackbar : MatSnackBar,
+    public loadingService: LoadingService,
+    router: Router,
+    snackbar: MatSnackBar
   ) {
-    router.events.forEach(ev => {
+    if (AppComponent.instance != null) console.error("AppComponent instance already set");
+    AppComponent.instance = this;
+    router.events.forEach((ev) => {
       if (ev instanceof NavigationEnd) {
         snackbar.dismiss();
       }
-    })
+    });
+  }
+
+  @HostListener('document:keydown.escape', ['$event'])
+  onEscape(event: KeyboardEvent) {
+    this.espapePressed.emit(null);
   }
 }

--- a/src/main/frontend/src/app/mapping/api.service.ts
+++ b/src/main/frontend/src/app/mapping/api.service.ts
@@ -377,6 +377,25 @@ export class ApiService {
     });
   }
 
+  downloadCsv(
+    projectName: string,
+    mappingConfigs: string[],
+    content: string,
+    filename: string
+  ): Observable<string> {
+    let params = new URLSearchParams();
+    params.set('content', content);
+    params.set('filename', filename);
+    params.set('project', projectName);
+    for (let mappingConfig of mappingConfigs) {
+      params.append('mappings', mappingConfig);
+    }
+    return this.http.post(this.codeListsUrl, params, {
+      responseType: 'text',
+      ...urlEncodedOptions,
+    });
+  }
+
   async peregrineIndex(text: string): Promise<Span[]> {
     let normalize = (text: string) => {
       // Python: print "".join(r"\u%x" % ord(c) for c in u"–—")

--- a/src/main/frontend/src/app/mapping/concepts-table/concepts-table.component.html
+++ b/src/main/frontend/src/app/mapping/concepts-table/concepts-table.component.html
@@ -23,7 +23,7 @@
     <ng-container matColumnDef="concept" sticky>
       <th mat-header-cell *matHeaderCellDef mat-sort-header>Concept</th>
       <td mat-cell *matCellDef="let concept" class="concept">
-        <mapping-concept tag="conceptTags[concept.id]" [concept]="concept"></mapping-concept>
+        <mapping-concept [tag]="conceptTags[concept.id]" [concept]="concept"></mapping-concept>
       </td>
     </ng-container>
   

--- a/src/main/frontend/src/app/mapping/data.ts
+++ b/src/main/frontend/src/app/mapping/data.ts
@@ -280,16 +280,8 @@ export class Mapping {
     return Array.from(tags);
   }
   static jsonifyReplacer(field: string, value: any): any {
-    if (this instanceof Mapping) {
-      switch (field) {
-        case 'undoStack':
-        case 'redoStack':
-        case 'conceptsByCode':
-          return;
-      }
-    }
     if (value instanceof Set) {
-      return [...value];
+      return Array.from(value);
     }
     return value;
   }

--- a/src/main/frontend/src/app/mapping/download-dialog/download-dialog.component.html
+++ b/src/main/frontend/src/app/mapping/download-dialog/download-dialog.component.html
@@ -4,11 +4,8 @@
     </h1>
     <button mat-icon-button mat-dialog-close><mat-icon>close</mat-icon></button>
 </div>
-<div *ngIf="numMappings > 25" class="inputs" mat-dialog-content>
-    The download is currently limited to 25 mappings at once. Working on it! Thanks for your patience.
-</div>
 
-<div *ngIf="numMappings <= 25" class="inputs" mat-dialog-content>
+<div class="inputs" mat-dialog-content>
     <mat-form-field>
         <mat-label>Name</mat-label>
         <input #filename matInput [value]="defaultFilename()">
@@ -26,8 +23,11 @@
             <span *ngIf="data.includeDescendants == IncludeDescendants.No">not</span>
             included (according to the mapping configuration).
         </span>
+        <br/>
+        The download may take some time, especially when descendant codes are included.
+        <br/>
+        Press the escape key to cancel the download.
     </p>
-    
     <p>
         <button mat-raised-button enabled="enabled" (click)="download('metadata', filename.value)"
             color="primary"><mat-icon>download</mat-icon>Mappings metadata</button>

--- a/src/main/frontend/src/app/mapping/download-dialog/download-dialog.component.ts
+++ b/src/main/frontend/src/app/mapping/download-dialog/download-dialog.component.ts
@@ -1,13 +1,17 @@
-import { Component, Inject } from '@angular/core';
+import { Component, HostListener, Inject } from '@angular/core';
 import { ApiService } from '../api.service';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MappingInfo } from '../persistency.service';
 import { MappingMeta } from '../data';
+import { AppComponent } from 'src/app/app.component';
+import { firstValueFrom, map, race, Subject, takeUntil } from 'rxjs';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { HttpErrorResponse } from '@angular/common/http';
 
 export enum IncludeDescendants {
   Yes = 0,
   No = 1,
-  PerMapping = 2
+  PerMapping = 2,
 }
 
 export function includeDescendants(value: boolean) {
@@ -23,15 +27,16 @@ export class DownloadDialogComponent {
   IncludeDescendants = IncludeDescendants;
   numMappings: number = 0;
   constructor(
-    private api : ApiService,
-    public dialogRef : MatDialogRef<DownloadDialogComponent>,
+    private api: ApiService,
+    private snackbar: MatSnackBar,
+    public dialogRef: MatDialogRef<DownloadDialogComponent>,
     @Inject(MAT_DIALOG_DATA)
-    public data : {
-      projectName : string;
-      version? : number;
-      mappingConfigs : string[];
-      mappings: { [key: string]: {name: string, meta: MappingMeta}};
-      includeDescendants : IncludeDescendants;
+    public data: {
+      projectName: string;
+      version?: number;
+      mappingConfigs: string[];
+      mappings: { [key: string]: { name: string; meta: MappingMeta } };
+      includeDescendants: IncludeDescendants;
     }
   ) {
     this.numMappings = data.mappingConfigs.length;
@@ -40,9 +45,9 @@ export class DownloadDialogComponent {
   defaultFilename(): string {
     if (this.data.mappingConfigs.length == 1) {
       let config = this.data.mappingConfigs[0];
-      let {name, meta} = this.data.mappings[config];
+      let { name, meta } = this.data.mappings[config];
       if (meta.system && meta.type) {
-        let versionSuffix = "";
+        let versionSuffix = '';
         if (this.data.version != undefined) {
           versionSuffix = `@v${this.data.version}`;
         }
@@ -50,20 +55,127 @@ export class DownloadDialogComponent {
       }
     }
     let s = this.data.mappingConfigs.length == 1 ? '' : 's';
-    return `${this.data.projectName}`
+    return `${this.data.projectName}`;
   }
 
-  download(content : string, filename : string) {
-    let url = new URL(this.api.codeListsUrl);
-    url.searchParams.set('content', content);
-    url.searchParams.set('filename', filename);
-    url.searchParams.set('project', this.data.projectName);
-    for (let mappingConfig of this.data.mappingConfigs) {
-      url.searchParams.append('mappings', mappingConfig);
+  async download(content: 'codelist' | 'metadata', filename: string) {
+    let csvContent: string;
+    let suffix = '';
+    switch (content) {
+      case 'codelist': {
+        try {
+          let csvContents: string[] = [];
+          for (let ix = 0; ix < this.data.mappingConfigs.length; ix++) {
+            let mappingConfig = this.data.mappingConfigs[ix];
+            let info = this.data.mappings[mappingConfig];
+            let name = [info.meta.system, info.name, info.meta.type]
+              .filter((v) => v)
+              .join('_');
+            let message = `Fetching ${ix + 1} of ${
+              this.numMappings
+            }: ${name}...`;
+            this.snackbar.open(message, undefined, { duration: undefined });
+            let cancelDownload = new Subject<void>();
+            let download = this.api
+              .downloadCsv(
+                this.data.projectName,
+                [mappingConfig],
+                content,
+                filename
+              )
+              .pipe(takeUntil(cancelDownload));
+            try {
+              let res = await firstValueFrom(
+                race([
+                  download.pipe(
+                    map((csvContent) => ({
+                      type: 'csvContent' as 'csvContent',
+                      csvContent,
+                    }))
+                  ),
+                  AppComponent.instance!.espapePressed.asObservable().pipe(
+                    map(() => ({ type: 'canceled' as 'canceled' }))
+                  ),
+                ])
+              );
+              switch (res.type) {
+                case 'csvContent':
+                  csvContents.push(res.csvContent);
+                  break;
+                case 'canceled':
+                  cancelDownload.next();
+                  this.snackbar.open('Download canceled.', 'Ok');
+                  return;
+              }
+            } catch (error) {
+              let errorMsg = (error as HttpErrorResponse).error;
+              let msg = `Could not download ${name}. ${errorMsg}`;
+              console.error(msg, error);
+              alert(msg);
+              return;
+            }
+          }
+          csvContent = concatCsvContents(csvContents);
+        } finally {
+          this.snackbar.dismiss();
+        }
+        break;
+      }
+      case 'metadata': {
+        csvContent = await firstValueFrom(
+          this.api.downloadCsv(
+            this.data.projectName,
+            this.data.mappingConfigs,
+            content,
+            filename
+          )
+        );
+        suffix = ' - metadata';
+        break;
+      }
     }
-    window.open(url, '_blank');
+    openCsv(csvContent, filename + suffix + '.csv', content);
   }
+
   close() {
     this.dialogRef.close();
   }
+}
+
+function concatCsvContents(csvContents: string[]): string {
+  let result = '';
+  let header: string | null = null;
+  for (let csvContent of csvContents) {
+    let ix = csvContent.indexOf('\n');
+    let header1 = csvContent.slice(0, ix);
+    if (header === null) {
+      header = header1;
+      result += csvContent;
+    } else {
+      if (header1 != header) {
+        console.error('expected same header', {
+          expected: header,
+          found___: header1,
+        });
+      }
+      result += csvContent.slice(ix + 1);
+    }
+  }
+  return result;
+}
+
+function openCsv(
+  csvContent: string,
+  filename: string,
+  content: 'codelist' | 'metadata'
+) {
+  let file = new File([csvContent], filename, { type: 'text/csv' });
+  const url = URL.createObjectURL(file);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }

--- a/src/main/frontend/src/app/mapping/folder-mappings/folder-mappings.component.ts
+++ b/src/main/frontend/src/app/mapping/folder-mappings/folder-mappings.component.ts
@@ -317,7 +317,7 @@ export class FolderMappingsComponent {
       ),
       includeDescendants: IncludeDescendants.PerMapping,
     };
-    this.dialog.open(DownloadDialogComponent, { data });
+    this.dialog.open(DownloadDialogComponent, { data, disableClose: true });
   }
 
   openMetaDataDialog(info: MappingInfo) {

--- a/src/main/frontend/src/app/mapping/history/history.component.ts
+++ b/src/main/frontend/src/app/mapping/history/history.component.ts
@@ -59,7 +59,7 @@ export class HistoryComponent {
       includeDescendants: IncludeDescendants.PerMapping,
       mappings: { [config]: {name: this.info.mappingName, meta: this.meta}},
     };
-    this.dialog.open(DownloadDialogComponent, { data })
+    this.dialog.open(DownloadDialogComponent, { data, disableClose: true })
   }
 
   selectedMappingConfig() {

--- a/src/main/frontend/src/app/mapping/mapping-view/mapping-view.component.ts
+++ b/src/main/frontend/src/app/mapping/mapping-view/mapping-view.component.ts
@@ -396,7 +396,7 @@ export class MappingViewComponent implements HasPendingChanges {
         },
       },
     };
-    this.dialog.open(DownloadDialogComponent, { data });
+    this.dialog.open(DownloadDialogComponent, { data, disableClose: true });
   }
 
   async save(summary: string) {

--- a/src/main/frontend/src/app/mapping/persistency.service.ts
+++ b/src/main/frontend/src/app/mapping/persistency.service.ts
@@ -269,7 +269,7 @@ export class PersistencyService {
 
   saveRevision(shortkey: string, mapping: Mapping, summary: string) {
     let body = new URLSearchParams();
-    let mappingJson = JSON.stringify(mapping, Mapping.jsonifyReplacer);
+    let mappingJson = JSON.stringify(mapping.toObject(), Mapping.jsonifyReplacer);
     body.append('mapping', mappingJson);
     body.append('summary', summary);
     let url = this.url + `/mapping/${shortkey}/save-revision`;


### PR DESCRIPTION
Enable the download of codelists of many mappings by downloading them one-by-one, displaying a counter, and combining them in a post-processing.
